### PR TITLE
Add vendor directory filters and quick contact actions

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,8 +5,12 @@ import {
   ArrowUpRight,
   CalendarDays,
   Download,
+  Globe,
   Link2,
+  Mail,
+  Phone,
   Plus,
+  Search,
   Sparkles,
 } from "lucide-react";
 import { format } from "date-fns";
@@ -17,6 +21,7 @@ import { InvoiceForm } from "@/components/crm/invoice-form";
 import { VendorForm } from "@/components/crm/vendor-form";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Card,
   CardContent,
@@ -28,7 +33,7 @@ import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useCrmData } from "@/hooks/use-crm-data";
 import { formatCurrency, formatDate } from "@/lib/format";
-import type { Client, Invoice } from "@/types/crm";
+import type { Client, Invoice, Vendor } from "@/types/crm";
 import { cn } from "@/lib/utils";
 
 const CLIENT_PIPELINE: { id: Client["status"]; label: string; accent: string }[] = [
@@ -52,9 +57,17 @@ const clientStatusLabels: Record<Client["status"], string> = {
   completed: "Completed",
 };
 
+const preferredContactLabels: Record<NonNullable<Vendor["preferredContact"]>, string> = {
+  email: "Email",
+  phone: "Phone",
+  text: "Text",
+};
+
 export default function HomePage() {
   const { data, isHydrated, addClient, addVendor, addEvent, addInvoice } = useCrmData();
   const [activeTab, setActiveTab] = useState("overview");
+  const [vendorSearch, setVendorSearch] = useState("");
+  const [vendorServiceFilter, setVendorServiceFilter] = useState<string>("all");
 
   const handleExport = () => {
     if (typeof window === "undefined") return;
@@ -186,6 +199,52 @@ export default function HomePage() {
     data.clients.forEach((client) => map.set(client.id, client));
     return map;
   }, [data.clients]);
+
+  const vendorServiceCounts = useMemo(() => {
+    const counts = data.vendors.reduce<Record<string, number>>((accumulator, vendor) => {
+      const key = vendor.service?.trim() || "Other";
+      accumulator[key] = (accumulator[key] ?? 0) + 1;
+      return accumulator;
+    }, {});
+
+    return Object.entries(counts)
+      .map(([service, count]) => ({ service, count }))
+      .sort((a, b) => a.service.localeCompare(b.service));
+  }, [data.vendors]);
+
+  const filteredVendors = useMemo(() => {
+    const searchValue = vendorSearch.trim().toLowerCase();
+
+    return data.vendors.filter((vendor) => {
+      const matchesService =
+        vendorServiceFilter === "all" || vendor.service.toLowerCase() === vendorServiceFilter.toLowerCase();
+
+      if (!matchesService) {
+        return false;
+      }
+
+      if (!searchValue) {
+        return true;
+      }
+
+      const haystack = [vendor.name, vendor.service, vendor.notes]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+
+      return haystack.includes(searchValue);
+    });
+  }, [data.vendors, vendorSearch, vendorServiceFilter]);
+
+  const hasVendorFilters = useMemo(
+    () => vendorServiceFilter !== "all" || vendorSearch.trim().length > 0,
+    [vendorSearch, vendorServiceFilter]
+  );
+
+  const handleResetVendorFilters = () => {
+    setVendorSearch("");
+    setVendorServiceFilter("all");
+  };
 
   if (!isHydrated) {
     return (
@@ -596,28 +655,144 @@ export default function HomePage() {
                         <CardTitle>Vendor roster</CardTitle>
                         <CardDescription>Trusted partners and sourcing notes</CardDescription>
                       </div>
-                      <Badge variant="neutral">{data.vendors.length} vendors</Badge>
+                      <Badge variant="neutral">
+                        {filteredVendors.length} of {data.vendors.length} vendors
+                      </Badge>
                     </CardHeader>
-                    <CardContent className="space-y-3">
-                      {data.vendors.map((vendor) => (
-                        <div key={vendor.id} className="space-y-3 rounded-xl border border-border/80 bg-muted/40 p-4">
-                          <div className="flex flex-wrap items-center justify-between gap-3">
-                            <div>
-                              <h3 className="text-base font-semibold text-foreground">{vendor.name}</h3>
-                              <p className="text-xs text-muted-foreground">{vendor.service}</p>
-                            </div>
-                            <Badge variant="neutral">{vendor.preferredContact}</Badge>
-                          </div>
-                          <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
-                            {vendor.email && <span>{vendor.email}</span>}
-                            {vendor.phone && <span>{vendor.phone}</span>}
-                            {vendor.website && <span>{vendor.website}</span>}
-                          </div>
-                          {vendor.notes && (
-                            <p className="text-sm text-muted-foreground/90">{vendor.notes}</p>
+                    <CardContent className="space-y-4">
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="relative w-full sm:max-w-xs">
+                          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                          <Input
+                            value={vendorSearch}
+                            onChange={(event) => setVendorSearch(event.target.value)}
+                            placeholder="Search vendor or service"
+                            className="pl-9"
+                            aria-label="Search vendors"
+                          />
+                        </div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <button
+                            type="button"
+                            onClick={() => setVendorServiceFilter("all")}
+                            className={cn(
+                              "flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium transition",
+                              vendorServiceFilter === "all"
+                                ? "border-primary/40 bg-primary/10 text-primary"
+                                : "border-border/60 bg-muted/40 text-muted-foreground hover:border-border/80 hover:text-foreground"
+                            )}
+                          >
+                            All
+                            <span className="rounded-full bg-background px-2 py-0.5 text-[10px] font-semibold text-muted-foreground">
+                              {data.vendors.length}
+                            </span>
+                          </button>
+                          {vendorServiceCounts.map(({ service, count }) => (
+                            <button
+                              key={service}
+                              type="button"
+                              onClick={() => setVendorServiceFilter(service)}
+                              className={cn(
+                                "flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium transition",
+                                vendorServiceFilter.toLowerCase() === service.toLowerCase()
+                                  ? "border-primary/40 bg-primary/10 text-primary"
+                                  : "border-border/60 bg-muted/40 text-muted-foreground hover:border-border/80 hover:text-foreground"
+                              )}
+                            >
+                              {service}
+                              <span className="rounded-full bg-background px-2 py-0.5 text-[10px] font-semibold text-muted-foreground">
+                                {count}
+                              </span>
+                            </button>
+                          ))}
+                          {hasVendorFilters && (
+                            <Button type="button" variant="ghost" size="sm" onClick={handleResetVendorFilters}>
+                              Clear filters
+                            </Button>
                           )}
                         </div>
-                      ))}
+                      </div>
+                      {filteredVendors.length === 0 ? (
+                        <p className="rounded-xl border border-dashed border-border/70 bg-muted/40 p-6 text-sm text-muted-foreground">
+                          {hasVendorFilters
+                            ? "No vendors match your filters right now. Adjust your search or add a new partner."
+                            : "Add your first vendor to start building your partner roster."}
+                        </p>
+                      ) : (
+                        filteredVendors.map((vendor) => (
+                          <div key={vendor.id} className="space-y-3 rounded-xl border border-border/80 bg-muted/40 p-4">
+                            <div className="flex flex-wrap items-center justify-between gap-3">
+                              <div>
+                                <h3 className="text-base font-semibold text-foreground">{vendor.name}</h3>
+                                <p className="text-xs text-muted-foreground">{vendor.service}</p>
+                              </div>
+                              {vendor.preferredContact ? (
+                                <Badge variant="neutral" className="capitalize">
+                                  Prefers {preferredContactLabels[vendor.preferredContact]}
+                                </Badge>
+                              ) : (
+                                <Badge variant="neutral">Flexible contact</Badge>
+                              )}
+                            </div>
+                            <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                              {vendor.email && <span>{vendor.email}</span>}
+                              {vendor.phone && <span>{vendor.phone}</span>}
+                              {vendor.website && <span>{vendor.website}</span>}
+                            </div>
+                            {(vendor.email || vendor.phone || vendor.website) && (
+                              <div className="flex flex-wrap items-center gap-2 text-xs">
+                                {vendor.email && (
+                                  <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    className="h-8 rounded-full px-3"
+                                    asChild
+                                  >
+                                    <a href={`mailto:${vendor.email}`} className="inline-flex items-center gap-1.5">
+                                      <Mail className="h-4 w-4" /> Email
+                                    </a>
+                                  </Button>
+                                )}
+                                {vendor.phone && (
+                                  <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    className="h-8 rounded-full px-3"
+                                    asChild
+                                  >
+                                    <a href={`tel:${vendor.phone}`} className="inline-flex items-center gap-1.5">
+                                      <Phone className="h-4 w-4" /> Call
+                                    </a>
+                                  </Button>
+                                )}
+                                {vendor.website && (
+                                  <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    className="h-8 rounded-full px-3"
+                                    asChild
+                                  >
+                                    <a
+                                      href={vendor.website}
+                                      target="_blank"
+                                      rel="noreferrer"
+                                      className="inline-flex items-center gap-1.5"
+                                    >
+                                      <Globe className="h-4 w-4" /> Site
+                                    </a>
+                                  </Button>
+                                )}
+                              </div>
+                            )}
+                            {vendor.notes && (
+                              <p className="text-sm text-muted-foreground/90">{vendor.notes}</p>
+                            )}
+                          </div>
+                        ))
+                      )}
                     </CardContent>
                   </Card>
                 </section>


### PR DESCRIPTION
## Summary
- add vendor search and service filter controls to the roster tab
- show preferred contact labels and quick email, phone, and site actions on each vendor card
- surface vendor counts for each service and empty states when filters hide all results

## Testing
- npm run lint *(fails: missing @eslint/eslintrc package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fe2981808321a4eae874929c7c84