### PR TITLE
Fix CRM helper overloads for generated IDs

### DIFF
--- a/src/hooks/use-crm-data.ts
+++ b/src/hooks/use-crm-data.ts
@@ -20,6 +20,16 @@ function withGeneratedId<T extends { id?: string }>(item: T) {
   };
 }
 
+type InvoiceItemInput = InvoiceItem | Omit<InvoiceItem, "id">;
+
+const withInvoiceItemId = (item: InvoiceItemInput): InvoiceItem => {
+  if ("id" in item && item.id) {
+    return { ...item, id: item.id };
+  }
+
+  return { ...item, id: nanoid() };
+};
+
 export function useCrmData() {
   const [data, setData] = useState<CRMData>(sampleData);
   const [isHydrated, setIsHydrated] = useState(false);
@@ -95,20 +105,14 @@ export function useCrmData() {
       invoices: [
         {
           ...withGeneratedId(invoice),
-          items: invoice.items.map((item) => ({
-            ...item,
-            id: item.id ?? nanoid(),
-          })),
+          items: invoice.items.map(withInvoiceItemId),
         },
         ...current.invoices,
       ],
     }));
 
-  const normalizeInvoiceItems = (items: (InvoiceItem | Omit<InvoiceItem, "id">)[]) =>
-    items.map((item) => ({
-      ...item,
-      id: item.id ?? nanoid(),
-    }));
+  const normalizeInvoiceItems = (items: InvoiceItemInput[]) =>
+    items.map(withInvoiceItemId);
 
   const updateInvoice = (invoiceId: string, invoice: Omit<Invoice, "id">) =>
     setData((current) => ({

--- a/src/hooks/use-crm-data.ts
+++ b/src/hooks/use-crm-data.ts
@@ -8,6 +8,11 @@ import type { CRMData, Client, Event, Invoice, InvoiceItem, Vendor } from "@/typ
 
 const STORAGE_KEY = "aacrm-storage-v1";
 
+function withGeneratedId(item: Omit<Client, "id">): Client;
+function withGeneratedId(item: Omit<Vendor, "id">): Vendor;
+function withGeneratedId(item: Omit<Event, "id">): Event;
+function withGeneratedId(item: Omit<Invoice, "id">): Invoice;
+function withGeneratedId<T extends { id?: string }>(item: T): T & { id: string };
 function withGeneratedId<T extends { id?: string }>(item: T) {
   return {
     ...item,


### PR DESCRIPTION
## Summary
- ensure the CRM helper returns correctly typed entities by overloading it for each CRM record type

## Testing
- npm run build *(fails: next/font could not fetch remote fonts in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e33ee25c308321a6cf6b59bde23200