### PR TITLE
Fix duplicate imports on homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,6 @@
 "use client";
 
 import { type DragEvent, useMemo, useState } from "react";
-import {
-  ArrowUpRight,
-  CalendarDays,
-  Download,
-  Globe,
-  Link2,
-  Mail,
-  Phone,
-  Plus,
-  Search,
-  Sparkles,
-} from "lucide-react";
-import { format } from "date-fns";
-
-import { useMemo, useState } from "react";
 import type { LucideIcon } from "lucide-react";
 import { BarChart3, Globe, Mail, Phone, Plus, Search, ShoppingBag, Sparkles, Users } from "lucide-react";
 import { ClientForm } from "@/components/crm/client-form";


### PR DESCRIPTION
## Summary
- remove duplicate React and lucide-react imports left after a merge in the homepage
- drop unused icon and date-fns imports from the page component

## Testing
- npm run build *(fails: Turbopack cannot fetch Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3495e1ce8832182e7d187e0f4073d