### PR TITLE
Fix duplicate useState import in HomePage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { type DragEvent, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
+import type { DragEvent } from "react";
 import type { LucideIcon } from "lucide-react";
 import { BarChart3, Globe, Mail, Phone, Plus, Search, ShoppingBag, Sparkles, Users } from "lucide-react";
 import { ClientForm } from "@/components/crm/client-form";


### PR DESCRIPTION
## Summary
- separate the DragEvent type import from the React value import to prevent duplicate useState declarations during build

## Testing
- npm run build *(fails: unable to download Google Fonts in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e34af688848321a1ebe180b3829d19