### PR TITLE
Replace NextAuth gate with offline Apple session

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,20 +29,20 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
-    "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
-    "eslint": "^9",
-    "eslint-config-next": "15.5.4",
-    "tailwindcss": "^4",
-    "typescript": "^5",
     "@playwright/test": "^1.49.1",
+    "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^5.0.4",
+    "eslint": "^9",
+    "eslint-config-next": "15.5.4",
     "jsdom": "^24.1.3",
+    "tailwindcss": "^4",
+    "typescript": "^5",
     "vitest": "^2.1.4"
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 
 import "./globals.css";
+import { AuthProvider } from "@/components/auth/auth-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -31,7 +32,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} min-h-screen bg-background text-foreground antialiased`}
       >
-        {children}
+        <AuthProvider>{children}</AuthProvider>
       </body>
     </html>
   );

--- a/src/components/auth/auth-provider.tsx
+++ b/src/components/auth/auth-provider.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+interface AuthUser {
+  name?: string;
+  email: string;
+}
+
+interface AuthSession {
+  user: AuthUser;
+  signedInAt: string;
+}
+
+type AuthStatus = "loading" | "authenticated" | "unauthenticated";
+
+interface AuthContextValue {
+  session: AuthSession | null;
+  status: AuthStatus;
+  signInWithApple: (user: AuthUser) => void;
+  signOut: () => void;
+}
+
+const AUTH_STORAGE_KEY = "aacrm-auth-session";
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+export function AuthProvider({ children }: AuthProviderProps) {
+  const [session, setSession] = useState<AuthSession | null>(null);
+  const [status, setStatus] = useState<AuthStatus>("loading");
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const stored = window.localStorage.getItem(AUTH_STORAGE_KEY);
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored) as AuthSession;
+        setSession(parsed);
+        setStatus("authenticated");
+        return;
+      } catch (error) {
+        console.warn("Failed to parse stored auth session", error);
+      }
+    }
+
+    setStatus("unauthenticated");
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || status === "loading") {
+      return;
+    }
+
+    if (session) {
+      window.localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(session));
+    } else {
+      window.localStorage.removeItem(AUTH_STORAGE_KEY);
+    }
+  }, [session, status]);
+
+  const signInWithApple = (user: AuthUser) => {
+    const trimmedEmail = user.email.trim();
+    if (!trimmedEmail) {
+      throw new Error("Email is required to sign in.");
+    }
+
+    const nextSession: AuthSession = {
+      user: {
+        email: trimmedEmail,
+        name: user.name?.trim() || undefined,
+      },
+      signedInAt: new Date().toISOString(),
+    };
+
+    setSession(nextSession);
+    setStatus("authenticated");
+  };
+
+  const signOut = () => {
+    setSession(null);
+    setStatus("unauthenticated");
+  };
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      session,
+      status,
+      signInWithApple,
+      signOut,
+    }),
+    [session, status]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+
+  return context;
+}

--- a/src/data/sample.ts
+++ b/src/data/sample.ts
@@ -64,6 +64,7 @@ export const sampleData: CRMData = {
       venue: "Seaside Conservatory",
       coordinator: "Amelia Sloan",
       timeline: "Ceremony 4pm, Dinner 6pm, Dancing 8pm",
+      vendorIds: ["vendor-aurora-florals", "vendor-lyra-catering"],
       status: "scheduled",
     },
     {
@@ -74,6 +75,7 @@ export const sampleData: CRMData = {
       venue: "Atrium 55",
       coordinator: "Miles Carter",
       timeline: "Keynote 7pm, Awards 8pm, Afterparty 10pm",
+      vendorIds: ["vendor-lyra-catering"],
       status: "in-progress",
     },
   ],

--- a/src/types/crm.ts
+++ b/src/types/crm.ts
@@ -30,6 +30,7 @@ export interface Event {
   venue: string;
   coordinator: string;
   timeline?: string;
+  vendorIds?: string[];
   status: "scheduled" | "in-progress" | "wrap-up";
 }
 


### PR DESCRIPTION
## Summary
- remove the NextAuth-based API route and configuration so the CRM no longer depends on remote Apple credentials
- introduce a local AuthProvider that persists an Apple-branded session in localStorage for offline access
- refresh the home page sign-in experience to collect an Apple ID email before unlocking the dashboard

## Testing
- npm run lint *(fails with existing lint warnings about legacy form hook dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e34808b18c8321ac17995b36300e0f