### PR TITLE
Fix duplicate React import in home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useMemo, useState } from "react";
 import type { DragEvent } from "react";
 import type { LucideIcon } from "lucide-react";
 import { Apple, BarChart3, Globe, Mail, Phone, Plus, Search, ShoppingBag, Sparkles, Users } from "lucide-react";


### PR DESCRIPTION
## Summary
- remove the redundant React import in the home page to resolve the duplicate identifier build failure

## Testing
- `npm run lint` (warnings: existing dependency and unused variable warnings in form components)


------
https://chatgpt.com/codex/tasks/task_e_68e350c07ae08321803f6106b4a4035e