### PR TITLE
Add deposit tracking to events and update overview metrics

### DIFF
--- a/src/data/sample.ts
+++ b/src/data/sample.ts
@@ -65,7 +65,10 @@ export const sampleData: CRMData = {
       coordinator: "Amelia Sloan",
       timeline: "Ceremony 4pm, Dinner 6pm, Dancing 8pm",
       vendorIds: ["vendor-aurora-florals", "vendor-lyra-catering"],
-      status: "scheduled",
+      status: "confirmed",
+      estimate: 38000,
+      deposit: 8000,
+      depositPaid: true,
     },
     {
       id: "event-northcoast-gala",
@@ -76,7 +79,10 @@ export const sampleData: CRMData = {
       coordinator: "Miles Carter",
       timeline: "Keynote 7pm, Awards 8pm, Afterparty 10pm",
       vendorIds: ["vendor-lyra-catering"],
-      status: "in-progress",
+      status: "bid",
+      estimate: 42000,
+      deposit: 5000,
+      depositPaid: false,
     },
   ],
   invoices: [

--- a/src/types/crm.ts
+++ b/src/types/crm.ts
@@ -31,7 +31,10 @@ export interface Event {
   coordinator: string;
   timeline?: string;
   vendorIds?: string[];
-  status: "scheduled" | "in-progress" | "wrap-up";
+  status: "contacted" | "bid" | "confirmed";
+  estimate?: number;
+  deposit?: number;
+  depositPaid?: boolean;
 }
 
 export interface InvoiceItem {


### PR DESCRIPTION
## Summary
- expand event records with estimate and deposit fields plus deposit paid tracking
- update event forms, listings, and sample data to support new contacted/bid/confirmed statuses
- surface total held deposits on the overview dashboard while showing deposit details alongside events

## Testing
- npm run lint *(fails: existing hook dependency warnings in form components)*

------
https://chatgpt.com/codex/tasks/task_e_68e35443a03c8321b078150a5ad22607