### PR TITLE
Make upcoming events editable from overview

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -162,6 +162,12 @@ export default function HomePage() {
     setEditingClientId((current) => (current === id ? null : current));
   };
 
+  const handleEventEditRequest = (eventId: string) => {
+    if (!eventId) return;
+    setEditingEventId(eventId);
+    setActiveTab("events");
+  };
+
   const isClientDrag = (event: DragEvent<HTMLElement>) => {
     const transfer = event.dataTransfer;
     if (!transfer) return false;
@@ -905,9 +911,15 @@ export default function HomePage() {
                       .map((vendorId) => vendorMap.get(vendorId) ?? null)
                       .filter((vendor): vendor is Vendor => Boolean(vendor));
                     return (
-                      <div
+                      <button
                         key={event.id}
-                        className="space-y-2 rounded-xl border border-border/70 bg-muted/40 p-4"
+                        type="button"
+                        onClick={() => handleEventEditRequest(event.id)}
+                        className={cn(
+                          "w-full space-y-2 rounded-xl border border-border/70 bg-muted/40 p-4 text-left",
+                          "transition hover:border-primary/60 hover:shadow-sm",
+                          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+                        )}
                       >
                         <div className="flex flex-wrap items-center justify-between gap-2">
                           <div>
@@ -934,7 +946,7 @@ export default function HomePage() {
                         {event.timeline && (
                           <p className="text-xs text-muted-foreground/80">{event.timeline}</p>
                         )}
-                      </div>
+                      </button>
                     );
                   })}
                 </CardContent>
@@ -1124,7 +1136,7 @@ export default function HomePage() {
                                   type="button"
                                   size="sm"
                                   variant="ghost"
-                                  onClick={() => setEditingEventId(event.id)}
+                                  onClick={() => handleEventEditRequest(event.id)}
                                 >
                                   Edit
                                 </Button>


### PR DESCRIPTION
## Summary
- add a shared helper to switch to the Events tab and populate the edit form
- make cards in the Upcoming events overview list interactive so they open the selected event in edit mode
- route existing edit buttons in the events calendar through the new helper for consistent behaviour

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e354daa190832199a90e60586eac0c