### PR TITLE
Fix vendor type to include cost property

### DIFF
--- a/src/types/crm.ts
+++ b/src/types/crm.ts
@@ -19,6 +19,7 @@ export interface Vendor {
   phone?: string;
   website?: string;
   preferredContact?: "email" | "phone" | "text";
+  cost?: number;
   notes?: string;
 }
 


### PR DESCRIPTION
## Summary
- add an optional `cost` field to the Vendor type so cost lookups type-check

## Testing
- npm run build *(fails: Next.js could not download Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4182f62508321ae2c1ee784b9fb85