### PR TITLE
Guard vendor filtering when service text is missing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -788,8 +788,10 @@ export default function HomePage() {
     const searchValue = vendorSearch.trim().toLowerCase();
 
     return data.vendors.filter((vendor) => {
+      const vendorServiceValue = vendor.service ?? "";
+      const vendorService = vendorServiceValue.toLowerCase();
       const matchesService =
-        vendorServiceFilter === "all" || vendor.service.toLowerCase() === vendorServiceFilter.toLowerCase();
+        vendorServiceFilter === "all" || vendorService === vendorServiceFilter.toLowerCase();
 
       if (!matchesService) {
         return false;


### PR DESCRIPTION
## Summary
- guard the vendor filtering logic against missing service text by normalizing through a safe fallback before lowercasing

## Testing
- npm run lint
- npm run build *(fails: Turbopack cannot fetch Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e41d45f6808321a0e037e4a0e12eed