### PR TITLE
Improve mobile layout responsiveness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6043,6 +6043,7 @@
       "version": "10.14.1",
       "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.14.1.tgz",
       "integrity": "sha512-0KZxU+Ela9rUCULqFsUUOYYkjh7OM1EWdIfG6///MtXd0t2/uUIf0iNV5i0KariMhRQ5jve/OY985nrAXFaZeQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@firebase/analytics": "0.10.8",
         "@firebase/analytics-compat": "0.2.14",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "firebase": "^10.11.0",
     "lucide-react": "^0.544.0",
     "nanoid": "^5.1.6",
     "next": "15.5.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-  "firebase": "^10.11.0",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -980,13 +980,13 @@ export default function HomePage() {
   return (
     <div className="min-h-screen bg-background">
       <header className="border-b border-border/50 bg-background/80 backdrop-blur">
-        <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-between gap-3 px-4 py-3 text-xs sm:text-sm">
-          <div className="flex items-center gap-3 text-muted-foreground">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-3 text-xs sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:text-sm">
+          <div className="flex flex-col items-start gap-1 text-muted-foreground sm:flex-row sm:items-center sm:gap-3">
             <span className="font-semibold uppercase tracking-[0.35em] text-foreground">AACRM</span>
             <span aria-hidden className="hidden h-4 border-l border-border/60 sm:inline" />
             <span>Signed in as {session.user?.name || session.user?.email || "your team"}</span>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2 sm:justify-end">
             {isOffline && (
               <Badge variant="outline" className="border-amber-300 bg-amber-100 text-amber-800">
                 Offline mode
@@ -1008,10 +1008,16 @@ export default function HomePage() {
 
       <main className="mx-auto w-full max-w-6xl px-4 py-10 sm:py-12">
         <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
-          <TabsList className="flex w-full flex-wrap justify-start gap-2 bg-muted/70 p-2 text-xs sm:text-sm">
-            <TabsTrigger value="overview">Overview</TabsTrigger>
-            <TabsTrigger value="records">Records</TabsTrigger>
-            <TabsTrigger value="billing">Billing</TabsTrigger>
+          <TabsList className="flex w-full flex-nowrap gap-2 overflow-x-auto bg-muted/70 p-2 text-xs sm:text-sm">
+            <TabsTrigger value="overview" className="flex-1 min-w-[92px] sm:min-w-[120px]">
+              Overview
+            </TabsTrigger>
+            <TabsTrigger value="records" className="flex-1 min-w-[92px] sm:min-w-[120px]">
+              Records
+            </TabsTrigger>
+            <TabsTrigger value="billing" className="flex-1 min-w-[92px] sm:min-w-[120px]">
+              Billing
+            </TabsTrigger>
           </TabsList>
 
           <TabsContent value="overview" className="space-y-6">
@@ -1453,10 +1459,16 @@ export default function HomePage() {
 
           <TabsContent value="records" className="space-y-8">
             <Tabs value={recordsTab} onValueChange={handleRecordsTabChange} className="space-y-6">
-              <TabsList className="flex w-full flex-wrap gap-2 bg-muted/70 p-2 text-xs sm:text-sm">
-                <TabsTrigger value="clients">Clients</TabsTrigger>
-                <TabsTrigger value="events">Events</TabsTrigger>
-                <TabsTrigger value="vendors">Vendors</TabsTrigger>
+              <TabsList className="flex w-full flex-nowrap gap-2 overflow-x-auto bg-muted/70 p-2 text-xs sm:text-sm">
+                <TabsTrigger value="clients" className="flex-1 min-w-[92px] sm:min-w-[110px]">
+                  Clients
+                </TabsTrigger>
+                <TabsTrigger value="events" className="flex-1 min-w-[92px] sm:min-w-[110px]">
+                  Events
+                </TabsTrigger>
+                <TabsTrigger value="vendors" className="flex-1 min-w-[92px] sm:min-w-[110px]">
+                  Vendors
+                </TabsTrigger>
               </TabsList>
 
               <TabsContent value="clients" className="space-y-6">
@@ -1474,9 +1486,9 @@ export default function HomePage() {
                         <CardTitle>Client roster</CardTitle>
                         <CardDescription>Recent activity and event context</CardDescription>
                       </div>
-                      <div className="flex flex-col items-end gap-2">
+                      <div className="flex flex-col items-start gap-2 sm:items-end">
                         <Badge variant="neutral">{data.clients.length} total</Badge>
-                        <div className="flex flex-wrap justify-end gap-2">
+                        <div className="flex flex-wrap justify-start gap-2 sm:justify-end">
                           {selectedClientIds.length > 0 && (
                             <Badge variant="outline" className="border-primary/40 text-primary">
                               {selectedClientIds.length} selected
@@ -1605,9 +1617,9 @@ export default function HomePage() {
                         <CardTitle>Production calendar</CardTitle>
                         <CardDescription>Keep venues, leads, and status aligned</CardDescription>
                       </div>
-                      <div className="flex flex-col items-end gap-2">
+                      <div className="flex flex-col items-start gap-2 sm:items-end">
                         <Badge variant="neutral">{data.events.length} events</Badge>
-                        <div className="flex flex-wrap justify-end gap-2">
+                        <div className="flex flex-wrap justify-start gap-2 sm:justify-end">
                           {selectedEventIds.length > 0 && (
                             <Badge variant="outline" className="border-primary/40 text-primary">
                               {selectedEventIds.length} selected
@@ -1759,11 +1771,11 @@ export default function HomePage() {
                         <CardTitle>Vendor roster</CardTitle>
                         <CardDescription>Trusted partners and sourcing notes</CardDescription>
                       </div>
-                      <div className="flex flex-col items-end gap-2">
+                      <div className="flex flex-col items-start gap-2 sm:items-end">
                         <Badge variant="neutral">
                           {filteredVendors.length} of {data.vendors.length} vendors
                         </Badge>
-                        <div className="flex flex-wrap justify-end gap-2">
+                        <div className="flex flex-wrap justify-start gap-2 sm:justify-end">
                           {selectedVisibleVendorCount > 0 && (
                             <Badge variant="outline" className="border-primary/40 text-primary">
                               {selectedVisibleVendorCount} selected
@@ -1821,45 +1833,47 @@ export default function HomePage() {
                             aria-label="Search vendors"
                           />
                         </div>
-                        <div className="flex flex-wrap items-center gap-2">
-                          <button
-                            type="button"
-                            onClick={() => setVendorServiceFilter("all")}
-                            className={cn(
-                              "flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium transition",
-                              vendorServiceFilter === "all"
-                                ? "border-primary/40 bg-primary/10 text-primary"
-                                : "border-border/60 bg-muted/40 text-muted-foreground hover:border-border/80 hover:text-foreground"
-                            )}
-                          >
-                            All
-                            <span className="rounded-full bg-background px-2 py-0.5 text-[10px] font-semibold text-muted-foreground">
-                              {data.vendors.length}
-                            </span>
-                          </button>
-                          {vendorServiceCounts.map(({ service, count }) => (
+                        <div className="w-full overflow-x-auto">
+                          <div className="flex w-max items-center gap-2">
                             <button
-                              key={service}
                               type="button"
-                              onClick={() => setVendorServiceFilter(service)}
+                              onClick={() => setVendorServiceFilter("all")}
                               className={cn(
                                 "flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium transition",
-                                vendorServiceFilter === service.toLowerCase()
+                                vendorServiceFilter === "all"
                                   ? "border-primary/40 bg-primary/10 text-primary"
                                   : "border-border/60 bg-muted/40 text-muted-foreground hover:border-border/80 hover:text-foreground"
                               )}
                             >
-                              {service}
+                              All
                               <span className="rounded-full bg-background px-2 py-0.5 text-[10px] font-semibold text-muted-foreground">
-                                {count}
+                                {data.vendors.length}
                               </span>
                             </button>
-                          ))}
-                          {hasVendorFilters && (
-                            <Button type="button" variant="ghost" size="sm" onClick={handleResetVendorFilters}>
-                              Clear filters
-                            </Button>
-                          )}
+                            {vendorServiceCounts.map(({ service, count }) => (
+                              <button
+                                key={service}
+                                type="button"
+                                onClick={() => setVendorServiceFilter(service)}
+                                className={cn(
+                                  "flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium transition",
+                                  vendorServiceFilter === service.toLowerCase()
+                                    ? "border-primary/40 bg-primary/10 text-primary"
+                                    : "border-border/60 bg-muted/40 text-muted-foreground hover:border-border/80 hover:text-foreground"
+                                )}
+                              >
+                                {service}
+                                <span className="rounded-full bg-background px-2 py-0.5 text-[10px] font-semibold text-muted-foreground">
+                                  {count}
+                                </span>
+                              </button>
+                            ))}
+                            {hasVendorFilters && (
+                              <Button type="button" variant="ghost" size="sm" onClick={handleResetVendorFilters}>
+                                Clear filters
+                              </Button>
+                            )}
+                          </div>
                         </div>
                       </div>
                       {filteredVendors.length === 0 ? (


### PR DESCRIPTION
## Summary
- refine the mobile header and top-level tab layout so navigation stays on a single row
- adjust records tab controls and action button stacks for better legibility on narrow screens
- allow vendor filters to scroll horizontally, keeping chips accessible on phones

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4a94c85208321b14531e86731e1a9