### PR TITLE
Fix build failure caused by unclosed tab markup

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -148,7 +148,6 @@ export default function HomePage() {
   } = useCrmData();
   const [activeTab, setActiveTab] = useState("records");
   const [vendorSearch, setVendorSearch] = useState("");
-  const [activeTab, setActiveTab] = useState("overview");
   const [recordsSearch, setRecordsSearch] = useState("");
   const [vendorServiceFilter, setVendorServiceFilter] = useState<string>("all");
   const [editingClientId, setEditingClientId] = useState<string | null>(null);
@@ -1099,6 +1098,7 @@ export default function HomePage() {
             <TabsTrigger value="records">Records</TabsTrigger>
             <TabsTrigger value="leads-arr">Leads and ARR</TabsTrigger>
             <TabsTrigger value="billing">Billing</TabsTrigger>
+          </TabsList>
           <TabsList className="flex w-full flex-nowrap gap-2 overflow-x-auto bg-muted/70 p-2 text-xs sm:text-sm">
             <TabsTrigger value="overview" className="flex-1 min-w-[92px] sm:min-w-[120px]">
               Overview
@@ -1164,6 +1164,7 @@ export default function HomePage() {
                 </CardContent>
               </Card>
             </section>
+          </TabsContent>
 
           <TabsContent value="overview" className="space-y-6">
             <section className="grid gap-6 xl:grid-cols-[2fr_1fr]">


### PR DESCRIPTION
## Summary
- close the top-level billing tabs list and the leads/ARR tab content so the page JSX parses correctly
- remove the duplicate `activeTab` state declaration that caused redeclaration errors during build

## Testing
- npm run build *(fails: Next.js cannot fetch Google Fonts from fonts.googleapis.com in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e516ea27c4832180015a716f93a362